### PR TITLE
fix initialization of json editor elements

### DIFF
--- a/app/assets/javascripts/trestle/jsoneditor.js
+++ b/app/assets/javascripts/trestle/jsoneditor.js
@@ -1,6 +1,6 @@
 //= require vendored_jsoneditor/jsoneditor
 
-Trestle.init(function (root) {
+Trestle.init(function (_, root) {
   $(root).find('[data-enable-jsoneditor]').each(function (index, element) {
     const $field = $(element).parent().find('input.json-text-area');
     let object;


### PR DESCRIPTION
Looks like the API changed a bit as of Trestle 0.9.2, this enables the JSON editor again