### PR TITLE
Fix error with Uglifier

### DIFF
--- a/app/assets/javascripts/trestle/jsoneditor.js
+++ b/app/assets/javascripts/trestle/jsoneditor.js
@@ -6,7 +6,7 @@ Trestle.init(function (_, root) {
     let object;
     try {
       object = JSON.parse($field.val());
-    } catch {
+    } catch(err) {
       object = {}
     }
 


### PR DESCRIPTION
Fixes Error:

Uglifier::Error: Unexpected token punc «{», expected punc «(»

I've got an error when building the Rails assets for production with the Javascript.
Adding a catch(err) fixes the syntax error
![Bildschirmfoto 2021-12-09 um 13 13 31](https://user-images.githubusercontent.com/147175/145394571-9f8401b0-95cd-43a4-8c44-950741606119.png)

